### PR TITLE
Fix issues with string reading from buffer

### DIFF
--- a/session.go
+++ b/session.go
@@ -130,12 +130,12 @@ func (s *session) executeQuery(stmt *h2stmt, t *transfer) ([]string, int32, erro
 		return nil, -1, err
 	}
 	// 3. Write Max rows
-	err = t.writeInt32(200)
+	err = t.writeInt32(0)
 	if err != nil {
 		return nil, -1, err
 	}
 	// 4. Write Fetch max size
-	err = t.writeInt32(64)
+	err = t.writeInt32(2147483647)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/transfer.go
+++ b/transfer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package h2go
 
 import (
+	"io"
 	"bufio"
 	"encoding/binary"
 	"fmt"
@@ -139,20 +140,8 @@ func (t *transfer) readString() (string, error) {
 		return "", nil
 	}
 	buf := make([]byte, n*2)
-	/*
-		var cur int32
-		for {
-			n2, err := t.buff.Read(buf[cur:n])
-			if err != nil {
-				return "", err
-			}
-			cur += int32(n2)
-			if cur == n {
-				break
-			}
-		}
-	*/
-	n2, err := t.buff.Read(buf)
+
+	n2, err := io.ReadFull(t.buff, buf)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Also increate the max fetch size to java Integer.MAX_VALUE (like in https://github.com/h2database/h2database/blob/45b609dec0e45125e6a93f85c9018d34551332a1/h2/src/main/org/h2/command/CommandRemote.java#L165 when scrollable)